### PR TITLE
fix: handle missing product file (PSDiagnostics.psm1) when checking catalog signature

### DIFF
--- a/dotnet/Devolutions.Authenticode/Authenticode.cs
+++ b/dotnet/Devolutions.Authenticode/Authenticode.cs
@@ -352,10 +352,17 @@ namespace Devolutions.Authenticode
                                     }
                                     else
                                     {
-                                        // ProductFile has to be Catalog signed. Hence validating
-                                        // to see if the Catalog API is functional using the ProductFile.
-                                        Signature productFileSignature = GetSignatureFromCatalog(productFile);
-                                        Signature.CatalogApiAvailable = (productFileSignature != null && productFileSignature.Status == SignatureStatus.Valid);
+                                        try
+                                        {
+                                            // ProductFile has to be Catalog signed. Hence validating
+                                            // to see if the Catalog API is functional using the ProductFile.
+                                            Signature productFileSignature = GetSignatureFromCatalog(productFile);
+                                            Signature.CatalogApiAvailable = (productFileSignature != null && productFileSignature.Status == SignatureStatus.Valid);
+                                        }
+                                        catch (IOException)
+                                        {
+                                            Signature.CatalogApiAvailable = false;
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
The signature validation logic attempted to check the catalog signature of PSDiagnostics.psm1 to verify catalog API availability. 

If the file was missing on disk, this would result in an unhandled IOException. This fix ensures we catch that and safely mark CatalogApiAvailable as false.