### PR TITLE
Disable nullable context in projects

### DIFF
--- a/dotnet/Devolutions.Authenticode.PowerShell/Devolutions.Authenticode.Powershell.csproj
+++ b/dotnet/Devolutions.Authenticode.PowerShell/Devolutions.Authenticode.Powershell.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <LangVersion>9</LangVersion>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/dotnet/Devolutions.Authenticode/Devolutions.Authenticode.csproj
+++ b/dotnet/Devolutions.Authenticode/Devolutions.Authenticode.csproj
@@ -7,7 +7,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <LangVersion>9</LangVersion>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/dotnet/Devolutions.Authenticode/ZipFile.cs
+++ b/dotnet/Devolutions.Authenticode/ZipFile.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
 using System.IO;
 using System.Text;
 using System.Runtime.InteropServices;


### PR DESCRIPTION
Nullable context was enabled in the projects when they were created. The code does not have nullable annotations and currently generates warnings. This is a problem because hints in IDE will recommend removing unnecessary null checks that are actually needed. This change disables nullable context to avoid these issues.